### PR TITLE
Remove Illuminate dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Navi is a simple package that allows you to return a WordPress menu as an iterab
 
 ## Requirements
 
-- [Sage](https://github.com/roots/sage) >= 9.0
 - [PHP](https://secure.php.net/manual/en/install.php) >= 7.1.3
 - [Composer](https://getcomposer.org/download/)
 
@@ -26,7 +25,7 @@ $ composer require log1x/navi
 
 ### Basic Usage
 
-By default, Navi returns a [fluent container](https://laravel.com/api/master/Illuminate/Support/Fluent.html) containing your navigation menu.
+Navi returns an object containing the menu object and an array of all the menu's items.
 
 ```php
 <?php
@@ -39,7 +38,7 @@ if ($navigation->isEmpty()) {
   return;
 }
 
-return $navigation->toArray();
+return $navigation->getItems();
 ```
 
 When building the navigation menu, Navi retains the menu object and makes it available using the `get()` method. By default, `get()` returns the raw[`wp_get_nav_menu_object()`](https://codex.wordpress.org/Function_Reference/wp_get_nav_menu_object) allowing you to access it directly. 
@@ -101,7 +100,7 @@ class Navigation extends Composer
             return;
         }
         
-        return Navi::build()->toArray();
+        return Navi::build()->getItems();
     }
 }
 ```
@@ -146,7 +145,7 @@ Here is an example using ACF with an optional custom label:
 
 ## Example Output
 
-When calling `build()`, Navi will parse the passed navigation menu and return a fluent container containing your menu items. To return an array of objects, simply call `->toArray()`.
+When calling `build()`, Navi will parse the passed navigation menu. To get an array of all the menu items, use `->getItems()`. 
 
 By default, `build()` calls `primary_navigation` which is the default menu theme location on Sage.
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -60,7 +60,7 @@ class Builder
     {
         $this->menu = $this->filter($menu);
 
-        if ($this->menu->isEmpty()) {
+        if (empty($this->menu)) {
             return;
         }
 
@@ -110,7 +110,7 @@ class Builder
     {
         return array_map(function ($item) {
             $collect = [];
-            foreach ($this->attributes as $value => $key) {
+            foreach ($this->attributes as $key => $value) {
                 $collect[$key] = $item->{$value};
             }
 

--- a/src/Navi.php
+++ b/src/Navi.php
@@ -2,9 +2,7 @@
 
 namespace Log1x\Navi;
 
-use Illuminate\Support\Fluent;
-
-class Navi extends Fluent
+class Navi
 {
     /**
      * The current menu object.
@@ -14,7 +12,37 @@ class Navi extends Fluent
     protected $menu;
 
     /**
-     * Build and assign the navigation menu items to the fluent instance.
+     * All of the menu items.
+     *
+     * @var array
+     */
+    protected $items = [];
+
+    /**
+     * Create a new Navi.
+     *
+     * @param  array|object  $attributes
+     * @return void
+     */
+    public function __construct($attributes = [])
+    {
+        foreach ($attributes as $key => $value) {
+            $this->items[$key] = $value;
+        }
+    }
+
+    /**
+     * Get an array of the menu items on this instance.
+     *
+     * @return array
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Build and assign the navigation menu items.
      *
      * @param  int|string|WP_Term $menu
      * @return $this
@@ -27,7 +55,7 @@ class Navi extends Fluent
 
         $this->menu = wp_get_nav_menu_object($menu);
 
-        $this->attributes = (new Builder())->build(
+        $this->items = (new Builder())->build(
             wp_get_nav_menu_items($this->menu)
         );
 
@@ -55,22 +83,22 @@ class Navi extends Fluent
     }
 
     /**
-     * Determine whether the fluent instance is empty.
+     * Determine whether the instance is empty.
      *
      * @return bool
      */
     public function isEmpty()
     {
-        return empty($this->attributes);
+        return empty($this->items);
     }
 
     /**
-     * Determine whether the fluent instance is not empty.
+     * Determine whether the instance is not empty.
      *
      * @return bool
      */
     public function isNotEmpty()
     {
-        return ! empty($this->attributes);
+        return ! empty($this->items);
     }
 }

--- a/src/Navi.php
+++ b/src/Navi.php
@@ -42,6 +42,16 @@ class Navi
     }
 
     /**
+     * Retained for historical reasons.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->getItems();
+    }
+
+    /**
      * Build and assign the navigation menu items.
      *
      * @param  int|string|WP_Term $menu

--- a/src/Navi.php
+++ b/src/Navi.php
@@ -2,7 +2,6 @@
 
 namespace Log1x\Navi;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 
 class Navi extends Fluent
@@ -23,7 +22,7 @@ class Navi extends Fluent
     public function build($menu = 'primary_navigation')
     {
         if (is_string($menu)) {
-            $menu = Arr::get(get_nav_menu_locations(), $menu, $menu);
+            $menu = get_nav_menu_locations()[$menu] ?? $menu;
         }
 
         $this->menu = wp_get_nav_menu_object($menu);


### PR DESCRIPTION
This removes the internal dependencies on the Illuminate helpers assumed to be provided by Sage 9/10. With this change, Navi should now be usable in any WordPress environment. I've done some minimal testing on an existing project, but more testing would certainly be wise.

This would represent a :warning: **breaking change** :warning: if implemented: It strips out _all_ Fluent functionality, so any user implementation depending on Fluent methods will immediately explode. If this is a real no-go, then I can look at just manually copying over the classes, etc, since we want to avoid any dependencies (and thus dependency hell w/ relatively popular packages). I left that out in this initial PR for the following reasons:

1. Navi is light, and I'd like to see it stay light
2. The use case(s) described in the Readme are still supported with this version (most of them involve getting an array out of Navi ultimately anyway and now it just uses arrays internally instead of collections)
3. It would feel gross to do that

Also of note:
I've added a method called `getItems()` which returns an array of items (i.e. you'd use it as `toArray()` is used in the original examples). I did this because `toArray()` makes no semantic sense when all internal data is now arrays. However I have added a `toArray()` method as well that just returns `getItems()` to make the transition from older user implementations a little easier.

Let me know if you'd like me to make any changes or take it in a different direction.