### PR TITLE
Implode classes array into string

### DIFF
--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -87,12 +87,14 @@ class MenuBuilder
         _wp_menu_item_classes_by_context($menu);
 
         return array_map(function ($item) {
-            $item->classes = array_filter($item->classes, function ($class) {
+            $classes = array_filter($item->classes, function ($class) {
                 return array_key_exists(
                     $class,
                     array_flip($this->classes)
                 );
             });
+
+            $item->classes = is_array($classes) ? implode(' ', $classes) : $classes;
 
             foreach ($item as $key => $value) {
                 if (empty($value)) {


### PR DESCRIPTION
### Summary

Implode `classes` array into a string.

### Issue

After Upgrading to `v2.0.0`, `$item->classes` are returned as an array instead of a space separated string as before. Not sure if this is intentional (if so I'll update my codebase).

**Menu item**

![Screenshot 2021-02-16 at 12 29 49](https://user-images.githubusercontent.com/1690006/108063289-e36af980-7052-11eb-837a-c46d47bb0cb3.png)
