### PR TITLE
Force $menu to array

### DIFF
--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -55,9 +55,9 @@ class MenuBuilder
      * @param  array $menu
      * @return array
      */
-    public function build($menu)
+    public function build($menu = [])
     {
-        $this->menu = $this->filter($menu);
+        $this->menu = $this->filter((array) $menu);
 
         if (empty($this->menu)) {
             return;

--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -55,7 +55,7 @@ class MenuBuilder
      * @param  array $menu
      * @return array
      */
-    public function build($menu = [])
+    public function build($menu)
     {
         $this->menu = $this->filter((array) $menu);
 


### PR DESCRIPTION
This is creating an error for locally, when booting up a new site. I'm getting this error:

```
 Warning: array_filter() expects parameter 1 to be array, bool given
```

This solves the error from popping up.