### PR TITLE
fix(menu-builder): prevents endless recurtion with Polylang plugin

### DIFF
--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -137,7 +137,10 @@ class MenuBuilder
     protected function tree($items, $parent = 0, $branch = [])
     {
         foreach ($items as $item) {
-            if ($item->parent == $parent) {
+            if (
+                $item->parent === false && $parent === 0 ||
+                strcmp($item->parent, $parent) === 0
+            ) {
                 $children = $this->tree($items, $item->id);
                 $item->children = ! empty($children) ? $children : [];
 


### PR DESCRIPTION
Polylang uses the same IDs on dropdown menus as the parent - just with a suffix:

```
    +"id": "343-en"
    +"label": "EN"
    +"objectId": "343"
    +"parent": 343
```

This caused an endless recursion with the old comparison.

fixes #11