### PR TITLE
Fix invalid example code for vanilla WordPress installation

### DIFF
--- a/examples/vanilla/template-parts/site-nav.php
+++ b/examples/vanilla/template-parts/site-nav.php
@@ -8,7 +8,7 @@
 $navigation = new \Log1x\Navi\Navi()->build('primary-menu');
 ?>
 
-<?php if ( $navigation->isNotEmpty() ) ) : ?>
+<?php if ( $navigation->isNotEmpty() ) : ?>
     <nav id="site-navigation" class="main-navigation">
         <ul id="primary-menu">
             <?php foreach ( $navigation->toArray() as $item ) : ?>


### PR DESCRIPTION
First, thanks so much for making this library.

The example for a vanilla WordPress site is a little off. This fixes it.

Thanks!