### PR TITLE
Support WPML translated menu

### DIFF
--- a/src/Navi.php
+++ b/src/Navi.php
@@ -46,7 +46,14 @@ class Navi implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     {
         if (is_string($menu)) {
             $locations = get_nav_menu_locations();
-            $menu = array_key_exists($menu, $locations) ? $locations[$menu] : $menu;
+
+            if (array_key_exists($menu, $locations)) {
+                $menu = $locations[$menu];
+
+                if (has_filter('wpml_object_id')) {
+                    $menu = apply_filters('wpml_object_id', $menu, 'nav_menu');
+                }
+            }
         }
 
         $this->menu = wp_get_nav_menu_object($menu);


### PR DESCRIPTION
When using WPML plugin for translated website and just calling `Navi::build('primary_navigation')` I expect the menu or the current language to be returned.

This gets the wpml translated menu ID if available returning the translated navigation items. Falls back to normal menu if WPML is not activated.