### PR TITLE
v3.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "php": "^8.0"
   },
   "require-dev": {
-    "laravel/pint": "^1.14"
+    "laravel/pint": "^1.14",
+    "roots/acorn": "^4.3"
   },
   "extra": {
     "acorn": {

--- a/examples/vanilla/template-parts/site-nav.php
+++ b/examples/vanilla/template-parts/site-nav.php
@@ -11,7 +11,7 @@ $navigation = \Log1x\Navi\Navi::make()->build('primary-menu');
 <?php if ( $navigation->isNotEmpty() ) : ?>
     <nav id="site-navigation" class="main-navigation">
         <ul id="primary-menu">
-            <?php foreach ( $navigation->toArray() as $item ) : ?>
+            <?php foreach ( $navigation->all() as $item ) : ?>
                 <li class="<?php echo $item->classes; ?> <?php echo $item->active ? 'current-item' : ''; ?>">
                     <a href="<?php echo $item->url; ?>">
                         <?php echo $item->label; ?>

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Navi
  * Plugin URI:  https://github.com/log1x/navi
  * Description: A developer-friendly alternative to the WordPress NavWalker.
- * Version:     3.0.3
+ * Version:     3.1.0
  * Author:      Brandon Nifong
  * Author URI:  https://github.com/log1x
  */

--- a/src/Console/NaviListCommand.php
+++ b/src/Console/NaviListCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Log1x\Navi\Console;
+
+use Illuminate\Console\Command;
+
+class NaviListCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'navi:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List registered navigation menus';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $registered = collect(get_registered_nav_menus());
+        $locations = collect(get_nav_menu_locations());
+        $menus = collect(wp_get_nav_menus());
+
+        $rows = $registered
+            ->map(fn ($label, $value) => $menus->firstWhere('term_id', $locations->get($value)))
+            ->map(fn ($menu, $location) => collect([
+                $location,
+                $menu?->name ?? 'Unassigned',
+                $menu?->count ?? 0,
+            ])->map(fn ($value) => $menu?->name ? $value : "<fg=red>{$value}</>"));
+
+        $this->table([
+            '<fg=blue>Location</>',
+            '<fg=blue>Assigned Menu</>',
+            '<fg=blue>Menu Items</>',
+        ], $rows, tableStyle: 'box');
+    }
+}

--- a/src/Console/NaviMakeCommand.php
+++ b/src/Console/NaviMakeCommand.php
@@ -41,9 +41,28 @@ class NaviMakeCommand extends GeneratorCommand
             return false;
         }
 
-        $name = strtolower(trim($this->argument('name')));
+        $component = Str::of($this->argument('name'))
+            ->lower()
+            ->trim();
 
-        $this->components->info("Navi component <fg=blue><x-{$name} /></> is ready for use.");
+        $default = $this->option('default') ?? 'primary_navigation';
+
+        $locations = collect(get_registered_nav_menus())
+            ->take(5)
+            ->map(fn ($name, $slug) => $slug === $default
+                ? "{$name}: <fg=blue><x-{$component} /></>"
+                : "{$name}: <fg=blue><x-{$component} name=\"{$slug}\" /></>"
+            );
+
+        $this->components->info("Navi component <fg=blue><x-{$component} /></> is ready for use.");
+
+        if ($locations->isEmpty()) {
+            $this->components->warn('Your theme does not appear to have any registered navigation menu locations.');
+
+            return;
+        }
+
+        $this->components->bulletList($locations->all());
     }
 
     /**

--- a/src/Exceptions/MenuLifecycleException.php
+++ b/src/Exceptions/MenuLifecycleException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Log1x\Navi\Exceptions;
+
+use Exception;
+
+class MenuLifecycleException extends Exception
+{
+    //
+}

--- a/src/Facades/Navi.php
+++ b/src/Facades/Navi.php
@@ -5,10 +5,16 @@ namespace Log1x\Navi\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static \Log1x\Navi\Navi build(string $menu = 'primary_navigation')
+ * @method static \Log1x\Navi\Navi build(mixed $menu = null)
+ * @method static \Log1x\Navi\Navi withClasses(string|array $classes)
+ * @method static \Log1x\Navi\Navi withoutClasses(string|array $classes)
+ * @method static \Log1x\Navi\Navi withDefaultClasses()
  * @method static mixed get(string $key = null, mixed $default = null)
  * @method static bool isEmpty()
  * @method static bool isNotEmpty()
+ * @method static array all()
+ * @method static array toArray()
+ * @method static string toJson(int $options = 0)
  *
  * @see \Log1x\Navi\Navi
  */

--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -23,6 +23,7 @@ class MenuBuilder
         'label' => 'title',
         'object' => 'object',
         'objectId' => 'object_id',
+        'order' => 'menu_order',
         'parent' => 'menu_item_parent',
         'slug' => 'post_name',
         'target' => 'target',
@@ -30,25 +31,12 @@ class MenuBuilder
         'type' => 'type',
         'url' => 'url',
         'xfn' => 'xfn',
-        'order' => 'menu_order',
     ];
 
     /**
-     * The disallowed menu classes.
+     * The classes to remove from menu items.
      */
-    protected array $disallowedClasses = [
-        'current-menu',
-        'current_page',
-        'sub-menu',
-        'menu-item',
-        'menu-item-type-post_type',
-        'menu-item-object-page',
-        'menu-item-type-custom',
-        'menu-item-object-custom',
-        'menu_item',
-        'page-item',
-        'page_item',
-    ];
+    protected array $withoutClasses = [];
 
     /**
      * Make a new Menu Builder instance.
@@ -93,7 +81,15 @@ class MenuBuilder
         _wp_menu_item_classes_by_context($menu);
 
         return array_map(function ($item) {
-            $classes = array_filter($item->classes, fn ($class) => ! in_array($class, $this->disallowedClasses));
+            $classes = array_filter($item->classes, function ($class) {
+                foreach ($this->withoutClasses as $value) {
+                    if (str_starts_with($class, $value)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            });
 
             $item->classes = is_array($classes) ? implode(' ', $classes) : $classes;
 
@@ -142,10 +138,18 @@ class MenuBuilder
             $item->children = $this->handle($items, $item->id);
 
             $menu[$item->id] = $item;
-
-            unset($item);
         }
 
         return $menu;
+    }
+
+    /**
+     * Remove classes from menu items.
+     */
+    public function withoutClasses(array $classes = []): self
+    {
+        $this->withoutClasses = $classes;
+
+        return $this;
     }
 }

--- a/src/Providers/NaviServiceProvider.php
+++ b/src/Providers/NaviServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Log1x\Navi\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Log1x\Navi\Console\NaviMakeCommand;
+use Log1x\Navi\Console;
 use Log1x\Navi\Navi;
 
 class NaviServiceProvider extends ServiceProvider
@@ -27,7 +27,8 @@ class NaviServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                NaviMakeCommand::class,
+                Console\NaviListCommand::class,
+                Console\NaviMakeCommand::class,
             ]);
         }
     }


### PR DESCRIPTION
## Change log

### Enhancements

- ✨ Add a `navi:list` command to show registered navigation menus
- ✨ Add support for allowing default CSS classes on menu items 
- 🚚 Change the `make:navi` command signature to `navi:make`
- 🧑‍💻 Improve the `navi:make` command output 
- 🎨 Improve disallowed menu class filtering
- 🎨 Use `all()` instead of `toArray()` in examples
- 🎨 Add missing methods to the Facade docblock
- 📝 Improve the README
- ➕ Add `roots/acorn` to the project in development

### Bug fixes

- 🩹 Properly remove default WordPress CSS classes from menu items (Fixes #84, #83, #78)