### PR TITLE
Fix blade component example

### DIFF
--- a/examples/sage/resources/views/components/navigation.blade.php
+++ b/examples/sage/resources/views/components/navigation.blade.php
@@ -4,7 +4,7 @@
   'active' => 'text-blue-500',
 ])
 
-@php($menu = Navi::build($name))
+@php($menu = Log1x\Navi\Navi::make()->build($name))
 
 @if ($menu->isNotEmpty())
   <ul {{ $attributes }}>


### PR DESCRIPTION
I believe `::build()` needed to be changed to `::make()->build()` anyway, but to make this truly a drop-in after a composer install it needs the full namespace